### PR TITLE
Fix bug with null academic subjects data in staff school associations

### DIFF
--- a/models/staging/edfi_3/base/base_ef3__staff_school_associations.sql
+++ b/models/staging/edfi_3/base/base_ef3__staff_school_associations.sql
@@ -24,7 +24,7 @@ renamed as (
         v:schoolReference   as school_reference,
         v:staffReference    as staff_reference,
         -- lists 
-        v:academic_subjects as v_academic_subjects,
+        v:academicSubjects as v_academic_subjects,
         v:gradeLevels       as v_grade_levels,
 
         -- edfi extensions


### PR DESCRIPTION
See:  https://txedexchange.atlassian.net/browse/HC-47

Test with:
```
cd git/tea-workforce-data-transformation
poetry shell
cd ../stadium_txexchange/dbt
dbt deps
dbt seed
dbt run
```

In Snowflake run this query:
`select * from stg_ef3__staff_school_associations  limit 100
`
Make sure there is data in v_academic_subjects column.